### PR TITLE
Fix: P0 Boundary Condition For Direct Ancestors

### DIFF
--- a/src/bdmmprime/distribution/BirthDeathMigrationDistribution.java
+++ b/src/bdmmprime/distribution/BirthDeathMigrationDistribution.java
@@ -477,15 +477,20 @@ public class BirthDeathMigrationDistribution extends SpeciesTreeDistribution {
                 } else {
                     if (!isRhoTip[node.getChild(childIndex ^ 1).getNr()]) {
 
-                        state.p0[saNodeType] = g.p0[saNodeType];
+                        for (int type = 0; type < parameterization.getNTypes(); type++) {
+                            state.p0[type] = g.p0[type];
+                        }
+
                         state.ge[saNodeType] = g.ge[saNodeType]
                                 .scalarMultiplyBy(system.s[intervalIdx][saNodeType]
                                         * (1 - system.r[intervalIdx][saNodeType]));
 
                     } else {
                         // TODO COME BACK AND CHANGE (can be dealt with with getAllPInitialConds)
-                        state.p0[saNodeType] = g.p0[saNodeType]
-                                * (1 - system.rho[intervalIdx][saNodeType]);
+                        for (int type = 0; type < parameterization.getNTypes(); type++) {
+                            state.p0[type] = g.p0[type] * (1 - system.rho[intervalIdx][type]);
+                        }
+
                         state.ge[saNodeType] = g.ge[saNodeType]
                                 .scalarMultiplyBy(system.rho[intervalIdx][saNodeType]
                                         * (1 - system.r[intervalIdx][saNodeType]));

--- a/test/bdmmprime/distribution/BirthDeathMigrationLikelihoodTest.java
+++ b/test/bdmmprime/distribution/BirthDeathMigrationLikelihoodTest.java
@@ -383,8 +383,8 @@ public class BirthDeathMigrationLikelihoodTest {
 
 		double logL = density.calculateLogP();
 
-        // Reference BDMM (version 0.2.0) 29/03/2018
-		assertEquals(-21.185194919464568 + labeledTreeConversionFactor(density), logL, 1e-5);
+        // Reference TypeMappedTree & Flow Implementation 18/03/2024
+		assertEquals(-22.82747259570373, logL, 1e-5);
 	}
 
 


### PR DESCRIPTION
These commits fix a bug related to the p_0 boundary conditions in case of a direct ancestor.

### Problem Description

The bug was located in the subtree likelihood calculation of the `BirthDeathMigrationDistribution` class. It occurred in the following scenario:

![scenario](https://github.com/tgvaughan/BDMM-Prime/assets/30937732/e72d4f24-3afd-4b4f-bb24-daffaa7d9342)

Node 1 is the root. Node 2 is an internal node. Node 3 is a leaf and connected to node 2 with an edge of zero length, thus it is a direct ancestor of node 2. Node 4 is another leaf connected to node 2 with an edge of positive length.

When integrating over edge e, the boundary condition at node 2 only contained the extinction probability p_0 for the type of node 3. All other entries for the initial state of p_0 were set to zero.

### Fix Description

The bug should be fixed by using all entries for the p_0 boundary condition. This is in accordance with the definition in the paper _Phylodynamics with Migration: A Computational Framework to Quantify Population Structure from Genomic Data_ by Kühnert et al. (see [equation (2)](https://academic.oup.com/mbe/article/33/8/2102/2578541#E8)).

### Other comments

An existing test case used an older version of BDMM as a reference. BDMM exhibited the same behavior. The test case was thus changed to use the result of the ´TypeMappedTree` implementation which works correctly.

Another test case was added that did not pass with the previous implementation. It takes advantage of the fact that the state for p_0 gets propagated towards the root by always using the left subtree. This means that for two trees identical up to rotation of two subtrees, the previous integration might produce different results.
