### PR TITLE
feat: add SkylineNodeTreeLogger

### DIFF
--- a/doc/manual.org
+++ b/doc/manual.org
@@ -1826,6 +1826,32 @@ The main inputs for the =TypedNodeTreeLogger= are:
   Typed tree whose node types to log.
 
 #+begin_src xml
+  <log spec="bdmmprime.mapping.SkylineNodeTreeLogger">
+    <!-- Inputs -->
+  </log>
+#+end_src
+
+This logger extends the node-typed tree output by =TypedNodeTreeLogger= by
+annotating each node with values from one or more skyline vector parameters
+evaluated at the node time and type.  The node times are computed using the
+provided =parameterization= (with optional =finalSampleOffset=), and the values
+are rounded to the requested decimal =precision=.
+
+The main inputs for the =SkylineNodeTreeLogger= are:
+- =typedTree= (=Tree=, required) ::
+  Typed tree whose node types to log.
+- =parameterization= (=Parameterization=, required) ::
+  Parameterization used to convert node heights to times at which skyline
+  parameters are evaluated.
+- =skylineParameter= (=SkylineVectorParameter=, required, multiple allowed) ::
+  One or more skyline vector parameters whose values are annotated at each node.
+- =finalSampleOffset= (=Function=, default 0.0) ::
+  Optional offset between the final sample and the end of the birth-death
+  process used when converting node heights to absolute times.
+- =precision= (=Integer=, default 6) ::
+  Number of decimal places used when logging skyline parameter values.
+
+#+begin_src xml
   <log spec="bdmmprime.mapping.TypeTreeStatsLogger">
     <!-- Inputs -->
   </log>

--- a/src/bdmmprime/mapping/SkylineNodeTreeLogger.java
+++ b/src/bdmmprime/mapping/SkylineNodeTreeLogger.java
@@ -73,6 +73,9 @@ public class SkylineNodeTreeLogger extends TypedNodeTreeLogger {
 
     @Override
     public String getStrippedNewick(Node node) {
+        // Iterate over all nodes including the root
+        // and annotate each node with skyline parameter values
+        // evaluated at the node time and type
         for (Node n : node.getAllChildNodesAndSelf()) {
             double nodeTime = parameterization.getNodeTime(n, finalSampleOffset);
 

--- a/src/bdmmprime/mapping/SkylineNodeTreeLogger.java
+++ b/src/bdmmprime/mapping/SkylineNodeTreeLogger.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019-2025 ETH Zurich
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bdmmprime.mapping;
+
+import beast.base.core.Description;
+import beast.base.core.Function;
+import beast.base.core.Input;
+import beast.base.evolution.tree.Node;
+import beast.base.inference.parameter.RealParameter;
+
+import bdmmprime.parameterization.Parameterization;
+import bdmmprime.parameterization.SkylineVectorParameter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Description("Logs a typed node tree, annotating each node with the values of "
+        + "one or more skyline vector parameters evaluated at the node time and type.")
+public class SkylineNodeTreeLogger extends TypedNodeTreeLogger {
+
+    public Input<Parameterization> parameterizationInput = new Input<>(
+            "parameterization",
+            "Parameterization used to convert node heights to times at which skyline parameters are evaluated.",
+            Input.Validate.REQUIRED);
+
+    public Input<List<SkylineVectorParameter>> skylineParametersInput = new Input<>(
+            "skylineParameter",
+            "One or more skyline vector parameters whose values are annotated at each node of the tree.",
+            new ArrayList<>(), Input.Validate.REQUIRED);
+
+    public Input<Function> finalSampleOffsetInput = new Input<>(
+            "finalSampleOffset",
+            "Optional time offset between the final sample and the end of the birth–death process, "
+                    + "used when converting node heights to absolute times. Default is 0.",
+            new RealParameter("0.0"), Input.Validate.OPTIONAL);
+
+    public Input<Integer> precisionInput = new Input<>(
+            "precision",
+            "Number of decimal places used when logging skyline parameter values. Default is 6.",
+            6, Input.Validate.OPTIONAL);
+
+    private List<SkylineVectorParameter> skylineParameters;
+    private Parameterization parameterization;
+    private double finalSampleOffset;
+    private int precision;
+
+    @Override
+    public void initAndValidate() {
+        super.initAndValidate();
+        skylineParameters = skylineParametersInput.get();
+        parameterization = parameterizationInput.get();
+        finalSampleOffset = finalSampleOffsetInput.get().getArrayValue();
+        precision = precisionInput.get() ;
+    }
+
+    @Override
+    public String getStrippedNewick(Node node) {
+        for (Node n : node.getAllChildNodesAndSelf()) {
+            double nodeTime = parameterization.getNodeTime(n, finalSampleOffset);
+
+            Object nodeType = n.getMetaData("type");
+            int typeIndex = nodeType != null ? (Integer) nodeType : 0;
+
+            for (int i = 0; i < skylineParameters.size(); i++) {
+                SkylineVectorParameter param = skylineParameters.get(i);
+                String paramName = param.getID() != null ? param.getID() : "param" + i;
+
+                double value = param.getValuesAtTime(nodeTime)[typeIndex];
+                BigDecimal rounded = new BigDecimal(value)
+                        .setScale(precision, RoundingMode.HALF_UP);
+                n.setMetaData(paramName, rounded);
+            }
+
+            n.metaDataString = n.getMetaDataNames().stream()
+                    .map(k -> k + "=" + n.getMetaData(k))
+                    .collect(Collectors.joining(","));
+        }
+
+        return super.getStrippedNewick(node);
+    }
+}

--- a/version.xml
+++ b/version.xml
@@ -1,4 +1,4 @@
-<package name="BDMM-Prime" version="2.6.3">
+<package name="BDMM-Prime" version="2.6.4">
   <depends on="BEAST.base" atleast="2.7.0" atmost="2.7.9"/>
   <depends on="BEAST.app" atleast="2.7.0" atmost="2.7.9"/>
   <depends on="SA" atleast="2.1.0"/>
@@ -11,6 +11,7 @@
     <provider classname="bdmmprime.mapping.TypedTipTreeLogger"/>
     <provider classname="bdmmprime.mapping.TransitionTimeLogger"/>
     <provider classname="bdmmprime.mapping.TypeMappingDurationLogger"/>
+    <provider classname="bdmmprime.mapping.SkylineNodeTreeLogger"/>
     <provider classname="bdmmprime.util.TipDatesFromTree"/>
     <provider classname="bdmmprime.util.priors.SmartZeroExcludingPrior"/>
     <provider classname="bdmmprime.util.priors.OUSkyGridPrior"/>


### PR DESCRIPTION
Add a SkylineNodeTreeLogger that annotates each node with the values of one or more skyline parameters evaluated at the node time and type when logging a typed node tree.